### PR TITLE
Fix in 32-bit cfgFields offset

### DIFF
--- a/peview.cpp
+++ b/peview.cpp
@@ -1878,7 +1878,7 @@ bool PEView::Init()
 			// parse CFG table
 			if ((loadConfigSize >= (uint32_t)(m_is64 ? 0x94 : 0x40)) && (m_is64 || (opt.dllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)))
 			{
-				size_t cfgFields = m_is64 ? 112 : 68;
+				size_t cfgFields = m_is64 ? 112 : 72;
 				reader.Seek(RVAToFileOffset(m_dataDirs[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG].virtualAddress + cfgFields));
 
 				uint64_t guardCFCheckFunctionPointer = m_is64 ? reader.Read64() : reader.Read32();


### PR DESCRIPTION
I used parts of your CFG table parsing implementation as a reference for the [XFG Marker x64dbg plugin](https://github.com/m417z/x64dbg-xfg-marker) (thanks!). During development, I noticed that the 32-bit `cfgFields` offset doesn't seem to be correct. Using [PEAnatomist](https://rammerlabs.alidml.ru/index-eng.html) I saw that the correct value is 72, not 68, see screenshot below.

There were some other magic numbers which I didn't quite understand, but I ended up not using them so I didn't investigate. Examples:
```cpp
if ((m_dataDirs.size() > IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG) && (m_dataDirs[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG].size >= 40))
// ...
if (!loadConfigSize || (loadConfigSize > 0x80))
	loadConfigSize = m_dataDirs[IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG].size;
// ...
if ((loadConfigSize >= (uint32_t)(m_is64 ? 0x94 : 0x40)) && (m_is64 || (opt.dllCharacteristics & IMAGE_DLLCHARACTERISTICS_GUARD_CF)))
```

Also, I checked several 32-bit system dlls on my system, and none of them had XFG signatures. I didn't find any information about it, but perhaps you know - is XFG even supported for 32-bit PEs?

![image](https://user-images.githubusercontent.com/4129781/231288997-50d3a3a6-7a79-4c20-a593-ee0b51700965.png)
